### PR TITLE
Add support for Sankey Charts

### DIFF
--- a/nivo_chart/__init__.py
+++ b/nivo_chart/__init__.py
@@ -52,7 +52,7 @@ def nivo_chart(data, layout, key=None):
         Required. The data to be visualized.
     layout: dict
         Required. The layout of the visualization.
-    key: str or None 
+    key: str or None
         An optional key that uniquely identifies this component. If this is
         None, and the component's arguments are changed, the component will
         be re-mounted in the Streamlit frontend and lose its current state.
@@ -80,6 +80,74 @@ def nivo_chart(data, layout, key=None):
 # app: `$ streamlit run nivo_chart/__init__.py`
 if not _RELEASE:
     import streamlit as st
+
+    sankey_chart = {
+        "data": {
+            "nodes": [
+                {"id": "John", "nodeColor": "hsl(52, 70%, 50%)"},
+                {"id": "Raoul", "nodeColor": "hsl(359, 70%, 50%)"},
+                {"id": "Jane", "nodeColor": "hsl(331, 70%, 50%)"},
+                {"id": "Marcel", "nodeColor": "hsl(267, 70%, 50%)"},
+                {"id": "Ibrahim", "nodeColor": "hsl(340, 70%, 50%)"},
+                {"id": "Junko", "nodeColor": "hsl(81, 70%, 50%)"},
+            ],
+            "links": [
+                {"source": "Marcel", "target": "Jane", "value": 80},
+                {"source": "Ibrahim", "target": "Raoul", "value": 162},
+                {"source": "Ibrahim", "target": "John", "value": 44},
+                {"source": "Ibrahim", "target": "Jane", "value": 58},
+                {"source": "Ibrahim", "target": "Marcel", "value": 73},
+                {"source": "Junko", "target": "Jane", "value": 50},
+                {"source": "Junko", "target": "Marcel", "value": 12},
+                {"source": "John", "target": "Junko", "value": 117},
+                {"source": "John", "target": "Raoul", "value": 159},
+                {"source": "Raoul", "target": "Marcel", "value": 81},
+            ],
+        },
+        "layout": {
+            "title": "Sankey Chart",
+            "type": "sankey",
+            "height": 500,
+            "margin": {"top": 40, "right": 160, "bottom": 40, "left": 50},
+            "align": "justify",
+            "colors": {"scheme": "category10"},
+            "nodeOpacity": 1,
+            "nodeHoverOthersOpacity": 0.35,
+            "nodeThickness": 18,
+            "nodeSpacing": 24,
+            "nodeBorderWidth": 0,
+            "nodeBorderColor": {"from": "color", "modifiers": [["darker", 0.8]]},
+            "nodeBorderRadius": 3,
+            "linkOpacity": 0.5,
+            "linkHoverOthersOpacity": 0.1,
+            "linkContract": 3,
+            "enableLinkGradient": True,
+            "labelPosition": "outside",
+            "labelOrientation": "vertical",
+            "labelPadding": 16,
+            "labelTextColor": {
+                "from": "color",
+                "modifiers": [["darker", 1]],
+            },
+            "legends": [
+                {
+                    "anchor": "bottom-right",
+                    "direction": "column",
+                    "translateX": 130,
+                    "itemWidth": 100,
+                    "itemHeight": 14,
+                    "itemDirection": "right-to-left",
+                    "itemsSpacing": 2,
+                    "itemTextColor": "#999",
+                    "symbolSize": 14,
+                    "effects": [{"on": "hover", "style": {"itemTextColor": "#000"}}],
+                },
+            ],
+        },
+    }
+    nivo_chart(
+        data=sankey_chart["data"], layout=sankey_chart["layout"], key="sankey_chart"
+    )
 
     bump_chart = {
         "data": [
@@ -207,8 +275,9 @@ if not _RELEASE:
         "layout": {
             "title": "Bump Chart",
             "type": "bump",
-            "height": 360,
-            "width": 640,
+            "height": 500,
+            # width should not be set if we want the components to be responsive
+            # "width": 640,
             "colors": {"scheme": "spectral"},
             "lineWidth": 3,
             "activeLineWidth": 6,
@@ -1127,8 +1196,9 @@ if not _RELEASE:
         "layout": {
             "title": "Calendar Heatmap",
             "type": "calendar",
-            "height": 400,
-            "width": 600,
+            "height": 500,
+            # width should not be set if we want the components to be responsive
+            # "width": 600,
             "from": "2015-03-01",
             "to": "2016-07-12",
             "emptyColor": "#eeeeee",
@@ -1153,7 +1223,11 @@ if not _RELEASE:
         },
     }
 
-    nivo_chart(data=calendar_chart["data"], layout=calendar_chart["layout"], key="calendar_chart")
+    nivo_chart(
+        data=calendar_chart["data"],
+        layout=calendar_chart["layout"],
+        key="calendar_chart",
+    )
 
     st.markdown("---")
 
@@ -1168,8 +1242,9 @@ if not _RELEASE:
         "layout": {
             "title": "Chord Diagram",
             "type": "chord",
-            "height": 400,
-            "width": 600,
+            "height": 500,
+            # width should not be set if we want the components to be responsive
+            # "width": 600,
             "keys": ["John", "Raoul", "Jane", "Marcel", "Ibrahim"],
             "margin": {"top": 60, "right": 60, "bottom": 90, "left": 60},
             "valueFormat": ".2f",
@@ -1204,4 +1279,6 @@ if not _RELEASE:
             ],
         },
     }
-    nivo_chart(data=chord_chart["data"], layout=chord_chart["layout"], key="chord_chart")
+    nivo_chart(
+        data=chord_chart["data"], layout=chord_chart["layout"], key="chord_chart"
+    )

--- a/nivo_chart/frontend/package.json
+++ b/nivo_chart/frontend/package.json
@@ -8,6 +8,7 @@
     "@nivo/chord": "^0.79.1",
     "@nivo/core": "^0.79.0",
     "@nivo/heatmap": "^0.79.1",
+    "@nivo/sankey": "^0.79.1",
     "@nivo/tooltip": "^0.79.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/nivo_chart/frontend/src/NivoChart.tsx
+++ b/nivo_chart/frontend/src/NivoChart.tsx
@@ -7,11 +7,13 @@ import React, { useEffect } from "react"
 import { ResponsiveBump } from "@nivo/bump"
 import { ResponsiveCalendar } from "@nivo/calendar"
 import { ResponsiveChord } from "@nivo/chord"
+import { ResponsiveSankey } from "@nivo/sankey"
 
 const NivoChart: React.FC<ComponentProps> = (props) => {
   const { data, layout, key } = props.args
   const style: React.CSSProperties = {}
-  style.width = layout.width || "600px"
+  // width should not be set if we want the components to be responsive
+  // style.width = layout.width || "600px"
   style.height = layout.height || "360px"
   useEffect(() => {
     Streamlit.setFrameHeight()
@@ -24,6 +26,7 @@ const NivoChart: React.FC<ComponentProps> = (props) => {
         <ResponsiveCalendar data={data} {...layout} />
       )}
       {layout.type === "chord" && <ResponsiveChord data={data} {...layout} />}
+      {layout.type === "sankey" && <ResponsiveSankey data={data} {...layout} />}
     </div>
   )
 }

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@ this project was created to allow render [Nivo](https://nivo.rocks/) charts
 - Chord Charts
 - Bump Charts
 - Calendar Charts
+- Sankey Charts
 
 ```
 pip install streamlit-nivo 
@@ -1138,6 +1139,74 @@ chord_chart = {
     },
 }
 nc.nivo_chart(data=chord_chart["data"], layout=chord_chart["layout"], key="chord_chart")
+
+sankey_chart = {
+    "data": {
+        "nodes": [
+            {"id": "John", "nodeColor": "hsl(52, 70%, 50%)"},
+            {"id": "Raoul", "nodeColor": "hsl(359, 70%, 50%)"},
+            {"id": "Jane", "nodeColor": "hsl(331, 70%, 50%)"},
+            {"id": "Marcel", "nodeColor": "hsl(267, 70%, 50%)"},
+            {"id": "Ibrahim", "nodeColor": "hsl(340, 70%, 50%)"},
+            {"id": "Junko", "nodeColor": "hsl(81, 70%, 50%)"},
+        ],
+        "links": [
+            {"source": "Marcel", "target": "Jane", "value": 80},
+            {"source": "Ibrahim", "target": "Raoul", "value": 162},
+            {"source": "Ibrahim", "target": "John", "value": 44},
+            {"source": "Ibrahim", "target": "Jane", "value": 58},
+            {"source": "Ibrahim", "target": "Marcel", "value": 73},
+            {"source": "Junko", "target": "Jane", "value": 50},
+            {"source": "Junko", "target": "Marcel", "value": 12},
+            {"source": "John", "target": "Junko", "value": 117},
+            {"source": "John", "target": "Raoul", "value": 159},
+            {"source": "Raoul", "target": "Marcel", "value": 81},
+        ],
+    },
+    "layout": {
+        "title": "Sankey Chart",
+        "type": "sankey",
+        "height": 500,
+        "margin": {"top": 40, "right": 160, "bottom": 40, "left": 50},
+        "align": "justify",
+        "colors": {"scheme": "category10"},
+        "nodeOpacity": 1,
+        "nodeHoverOthersOpacity": 0.35,
+        "nodeThickness": 18,
+        "nodeSpacing": 24,
+        "nodeBorderWidth": 0,
+        "nodeBorderColor": {"from": "color", "modifiers": [["darker", 0.8]]},
+        "nodeBorderRadius": 3,
+        "linkOpacity": 0.5,
+        "linkHoverOthersOpacity": 0.1,
+        "linkContract": 3,
+        "enableLinkGradient": True,
+        "labelPosition": "outside",
+        "labelOrientation": "vertical",
+        "labelPadding": 16,
+        "labelTextColor": {
+            "from": "color",
+            "modifiers": [["darker", 1]],
+        },
+        "legends": [
+            {
+                "anchor": "bottom-right",
+                "direction": "column",
+                "translateX": 130,
+                "itemWidth": 100,
+                "itemHeight": 14,
+                "itemDirection": "right-to-left",
+                "itemsSpacing": 2,
+                "itemTextColor": "#999",
+                "symbolSize": 14,
+                "effects": [{"on": "hover", "style": {"itemTextColor": "#000"}}],
+            },
+        ],
+    },
+}
+nivo_chart(
+    data=sankey_chart["data"], layout=sankey_chart["layout"], key="sankey_chart"
+)
 
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="streamlit-nivo",
-    version="0.1.7",
+    version="0.1.8",
     author="Ahmed Saleh",
     author_email="a.saleh.ismael@gmail.com",
     description="Render Nivo charts in Streamlit",


### PR DESCRIPTION
This PR adds support for Sankey Charts.

Some comments:
- I added a working example to the `__init__.py` file and to the README.
- I commented out the width definition in the Typescript side as it enabled the charts to be responsive and adapt to changes in the browser width.